### PR TITLE
Prevent multiedges in generating undirected graphs

### DIFF
--- a/scripts/generate-random-graph.py
+++ b/scripts/generate-random-graph.py
@@ -21,9 +21,9 @@ def generate_random_graph(vertices, edges, undirected):
     graph['edges'] = random.sample(possible_edges, edges)
 
     if undirected:
-        backwards_edges = [(target, source)
-                           for (source, target) in graph['edges']]
-        graph['edges'] += backwards_edges
+        backwards_edges = set((target, source)
+                           for (source, target) in graph['edges'])
+        graph['edges'] = list(set(graph['edges']) | backwards_edges)
 
     return graph
 


### PR DESCRIPTION
Previously it was possible to add multiedges in undirected graphs when generating backwards
edges, if both the edges (u, v) and (v, u) were already randomly sampled for the
directed graph.

One can fix that by removing duplicate edges using a `set`.

The last `list()` conversion could also be
- dropped using `set` as an iterable directly or
- replaced with `sorted` to ensure nicer output.